### PR TITLE
fitting: Fail on undefined constants/initial values

### DIFF
--- a/oitg/fitting/FitBase.py
+++ b/oitg/fitting/FitBase.py
@@ -23,11 +23,19 @@ class FitParameters:
         """
 
         self.parameter_dict = {}
-        self.constant_parameter_names = constant_parameters.keys()
-        self.initialised_parameter_names = initialised_parameters.keys()
+        self.constant_parameter_names = set(constant_parameters.keys())
+        self.initialised_parameter_names = set(initialised_parameters.keys())
 
         # Check the contant and initialisation parameters for dodgy entries
-        # TODO
+        names = set(names)
+        undefined_constants = self.constant_parameter_names - names
+        if undefined_constants:
+            raise FitError("Parameters specified as constant "
+                           "do not exist: {}".format(undefined_constants))
+        undefined_initialised = self.initialised_parameter_names - names
+        if undefined_initialised:
+            raise FitError("Initial values specified for parameters that "
+                           "do not exist: {}".format(undefined_initialised))
 
         for name in names:
             if name in self.constant_parameter_names:
@@ -41,8 +49,7 @@ class FitParameters:
 
         # A list of names of those parameters which are to be variables
         # i.e. all of the remaining parameters
-        self.variable_names = list(set(self.parameter_dict.keys())
-                                   - set(self.constant_parameter_names))
+        self.variable_names = list(names - self.constant_parameter_names)
 
         # Internally set to true to stop initialisation parameters from
         # being overwritten during auto-initialisation

--- a/oitg/fitting/__init__.py
+++ b/oitg/fitting/__init__.py
@@ -1,3 +1,4 @@
+from .FitBase import FitError
 from .cos import cos, cos_fft
 from .cos_2 import cos_2, cos_2_fft
 from .decaying_sinusoid import decaying_sinusoid

--- a/test/fitting/test_base.py
+++ b/test/fitting/test_base.py
@@ -1,0 +1,13 @@
+import numpy as np
+import unittest
+from oitg.fitting import cos, FitError
+
+
+class TestUndefinedParam(unittest.TestCase):
+    def test_undefined_constant(self):
+        with self.assertRaises(FitError):
+            cos.fit([1, 2, 3, 4], [5, 6, 7, 8], constants={"this_does_not_exist": 0.0})
+
+    def test_undefined_initial_value(self):
+        with self.assertRaises(FitError):
+            cos.fit([1, 2, 3, 4], [5, 6, 7, 8], initialise={"this_does_not_exist": 0.0})


### PR DESCRIPTION
This avoids situations where the user thinks a given value is
used, but in fact it used to be silently ignored.