### PR TITLE
FitBase: Don't set scale for constant parameters

### DIFF
--- a/oitg/fitting/FitBase.py
+++ b/oitg/fitting/FitBase.py
@@ -43,10 +43,6 @@ class FitParameters:
             if name in self.constant_parameter_names:
                 # If the parameter should be constant, set its value
                 self.parameter_dict[name] = constant_parameters[name]
-                if constant_parameters[name] != 0:
-                    self.scale_dict[name] = abs(constant_parameters[name])
-                else:
-                    self.scale_dict[name] = 1.0
             elif name in self.initialised_parameter_names:
                 # If the parameter should be initialised
                 self.parameter_dict[name] = initialised_parameters[name]


### PR DESCRIPTION
The scale is not needed for constant parameters. Further, the check
`constant_parameters[name] != 0` is incompatible with the kludge in
`dipole_bsb_car_rsb` where a numpy array is passed as a constant.