### PR TITLE
fitting (linear): fix indexing

### DIFF
--- a/oitg/fitting/line.py
+++ b/oitg/fitting/line.py
@@ -4,8 +4,8 @@ import numpy.fft
 from . import FitBase
 
 def parameter_initialiser(x, y, p):
-    k = (y[-1] - y[1]) / (x[-1] - x[1])
-    p['a'] = y[1] - x[1] * k
+    k = (y[-1] - y[0]) / (x[-1] - x[0])
+    p['a'] = y[0] - x[0] * k
     p['b'] = k
 
 def fitting_function(x, p):


### PR DESCRIPTION
The linear fitting function used 1-indexed array notation instead of the Python-default 0-indexing. We discovered this by ending up with a divide-by-zero error when our x-values were roughly set to [0, 1], so the two 1 values were subtracted from each other.