### PR TITLE
results.py: Convenience functions for extracting and sorting ndscan experiments

### DIFF
--- a/oitg/results.py
+++ b/oitg/results.py
@@ -7,6 +7,8 @@ import shutil
 import os
 import re
 from typing import Any, Dict, List, NamedTuple, Optional, Tuple, Union
+from sipyco import pyon
+import numpy as np
 from . import rid_index
 from .paths import artiq_results_path
 
@@ -249,3 +251,175 @@ def load_by_magic(rid_or_path):
     if params:
         return load_result(**params)
     return load_hdf5_file(rid_or_path)
+
+
+def load_ndscan(
+    day: Union[None, str, List[str]] = None,
+    hour: Union[None, int, List[int]] = None,
+    rid: Union[None, int, List[int]] = None,
+    class_name: Union[None, str, List[str]] = None,
+    experiment: Optional[str] = None,
+    root_path: Optional[str] = None,
+    return_results: bool = False,
+) -> Tuple[
+    Dict[str, Any], List[Dict[str, Any]], Dict[str, Any], Optional[Dict[str, Any]]
+]:
+    """
+    Unpacks the results from an N-dimensional ndscan experiment to make scan data
+    and axes more accessible. Returns sorted results and axes.
+
+    :return: A tuple containing the following:
+        - scan_results: a dictionary containing dictionaries of scan data for each
+            results channel, mapped to by the name of the results channel. Each scan
+            dictionary contains entries:
+
+                - data: numpy N-dimensional array (or N+M dimensional for results
+                    channels with M-dimensional lists) containing data sorted according
+                    to the sorted scan axes.
+                - data_raw: numpy array containing the raw scan results.
+                - spec: results spec.
+
+        - scan_axes: a list of dictionaries containing a dictionary of axes data for
+            each scanned param. The axes are ordered with the innermost axis first.
+            Each axis dictionary contains entries:
+
+                - data: numpy array containing the sorted axis data.
+                - data_raw: numpy array containing the raw scanned axis data.
+                - description: The param description provided in the experiment (if any).
+                - path: Path to the scanned param.
+                - spec: Param spec.
+                - ax_idx: The index of the axis in the N-dimensional scan, with 0 being
+                    the innermost axis being scanned.
+
+        - args: A dictionary containing the arguments submitted to the experiment.
+
+        - raw_results: the raw output of load_result().
+    """
+    # TODO: add analyses and annotations.
+    raw_results = load_result(
+        day=day,
+        hour=hour,
+        rid=rid,
+        class_name=class_name,
+        experiment=experiment,
+        root_path=root_path,
+    )
+    d = raw_results["datasets"]
+    a = raw_results["expid"]["arguments"]
+    base_key = f"ndscan.rid_{rid}."
+
+    axs = json.loads(d[base_key + "axes"])
+    if axs == []:
+        scan_axes = []
+        points_key = "point."
+    else:
+        scan_axes = [
+            {
+                "data_raw": d[base_key + f"points.axis_{i}"],
+                "description": ax["param"].get("description", None),
+                "path": ax["path"],
+                "spec": ax["param"]["spec"],
+                "ax_idx": i,
+            }
+            for i, ax in enumerate(axs)
+        ]
+        points_key = "points.channel_"
+
+    ndscan_results_channel_spec = json.loads(d[base_key + "channels"])
+    scan_results = {}
+    for chan, spec in ndscan_results_channel_spec.items():
+        try:
+            scan_results[chan] = {
+                "data_raw": d[base_key + points_key + chan],
+                "spec": spec,
+            }
+        except KeyError:
+            print(f"Results channel {chan} not found.")
+
+    scan_results, scan_axes = sort_data(scan_results, scan_axes)
+
+    args = {}
+    for key, arg in a.items():
+        if key == "ndscan_params":
+            ndscan_params = pyon.decode(arg)
+            for fqn, overrides in ndscan_params["overrides"].items():
+                for override in overrides:
+                    schem = ndscan_params["schemata"][fqn]
+                    value = override["value"]
+                    description = schem["description"]
+                    path = override["path"]
+                    try:
+                        args[description] = {
+                            "value": value,
+                            "fqn": fqn,
+                            "path": path,
+                            "unit": schem.get("unit", ""),
+                            "scale": schem["spec"]["scale"],
+                            "ndscan": True,
+                        }
+                    except KeyError:
+                        print(fqn)
+
+            args["scan"] = ndscan_params["scan"]
+
+        else:
+            args[key] = {"value": arg, "ndscan": False}
+    args["completed"] = d[base_key + "completed"]
+
+    if return_results:
+        return scan_results, scan_axes, args, raw_results
+    else:
+        return scan_results, scan_axes, args
+
+
+def sort_data(
+    scan_results: Dict[str, Any], scan_axes: List[Dict[str, Any]]
+) -> Tuple[Dict[str, Any], List[Dict[str, Any]]]:
+    """
+    Sort the results of an N-dimensional scan. Takes in dictionaries with
+    entries 'data_raw' and adds an entry 'data' with a sorted scan axis, or
+    a sorted N-dimensional array of results values that match the axes. If a
+    result value is missing (due to eg an unfinished refined scan), entries
+    are left as np.nan.
+
+    Returns the (mutated) input scan_results and scan_axes dictionaries. If
+    the scan data can't be sorted, sets 'data' entry to None.
+    """
+    # Sort the axis data into 1-D arrays.
+    for axis in scan_axes:
+        axis["data"] = np.unique(axis["data_raw"])
+    axes_lengths = [np.size(ax["data"]) for ax in scan_axes]
+    num_points = len(scan_axes[0]["data_raw"])
+
+    # Find the coordinates of each point in the raw result data according to the
+    # sorted axes.
+    coords = []
+    for point_num in range(num_points):
+        _coords = []
+        for ax in scan_axes:
+            idcs = np.nonzero(ax["data"] == ax["data_raw"][point_num])
+            _coords.append(idcs[0][0])
+        coords.append(tuple(np.flip(_coords)))
+
+    # Create N-dimensional arrays that store the result data, according to the obtained coordinates.
+    # If a coordinate is missing (due to eg an unfinished refined scan) leaves entry as nan.
+    for key, dat_dict in scan_results.items():
+        try:
+            dat = dat_dict["data_raw"]
+        except IndexError:
+            print(f"Key 'data_raw' missing in dictionary for {key}")
+        try:
+            # Take into account results channels that are arrays.
+            data_shape = np.shape(dat)
+            _axes = tuple(
+                np.concatenate((np.flip(axes_lengths), data_shape[1:])).astype(int)
+            )
+            _dat_sorted = np.zeros(_axes) + np.nan
+            for point_number, d in enumerate(dat):
+                _dat_sorted[coords[point_number]] = d
+            scan_results[key]["data"] = _dat_sorted
+        except Exception:
+            print(f"Couldn't sort results channel {key}. Setting 'data' entry to None")
+            scan_results[key]["data"] = None
+
+    return scan_results, scan_axes


### PR DESCRIPTION
Some simple convenience functions that have been helpful to me, and I think may be helpful to others. They parse the results dictionary yielded by `load_results` to translate all PYON into python objects and make data more accessible. There are also functions to sort a multi-dimensional scan, possibly with missing entries (only tested for 2-D scans so far). 

Demo usage for loading a ragged 2D scan:
`scan_results, scan_axes, args = load_ndscan(day=day, rid=rid, experiment="abaqus")

data = scan_results["measurement_camera_readout_p_0"]["data"]
axis_0 = scan_axes[0]["data"] / scan_axes[0]["spec"]["scale"]
axis_1 = scan_axes[1]["data"] / scan_axes[1]["spec"]["scale"]

plt.pcolormesh(axis_0, axis_1, data)
plt.xlabel(f"{scan_axes[0]['description']} ({scan_axes[0]['spec']['unit']})")
plt.ylabel(f"{scan_axes[1]['description']} ({scan_axes[1]['spec']['unit']})")
`
