### PR TITLE
Document qubit ordering convention in `Gate`s

### DIFF
--- a/oitg/circuits/gate.py
+++ b/oitg/circuits/gate.py
@@ -9,6 +9,14 @@ A :class:`Gate` is a named tuple
 list of float values parametrising the chosen gate (e.g. rotation angles). ``operands``
 is a list of integer indices denoting the target qubits.
 
+The convention used for the indexing of the ``operand`` parameter is left-to-right
+in a bit-string. In other words, if a register is in state `|00...0>`, applying a
+`π` pulse on `operand = 0` results in the state `|10...0>`. The representation of
+an n-qubit state vector as a `numpy` array follows the convention 
+`[c_{00...0}, c_{00...1}, ..., c_{11...0}, c_{11...1}]`. The effect of the `π` pulse
+above in the 2-qubit case is to transform the array `[1.0, 0.0, 0.0, 0.0]` to 
+`[0.0, 0.0, -1.0j, 0.0]`
+
 This is deliberately just a plain piece of data to make gates directly representable in
 ARTIQ kernels as well (with the tuples expressed as ``TList``\ s). Even apart from that,
 coming up with an extensible design for representing both values and operations isn't


### PR DESCRIPTION
The convention used for determining which qubit in a register is adressed by a `Gate` was not clear from the documentation.

If we apply a $\pi$ pulse on `operand=0` onto a two-qubit register initialised in $\ket{00}$, the outcome is the following:

```
from oitg.circuits.gate import Gate
from oitg.circuits.to_matrix import apply_gate_sequence

gate_seq = (Gate(kind="rx", parameters=(np.pi, ), operands=(0,)),)
state = np.array([1.0, 0.0, 0.0, 0.0])
np.abs(apply_gate_sequence(gate_seq, state))
# returns array([6.123234e-17, 0.000000e+00, 1.000000e+00, 0.000000e+00])
```
If the components of the two-qubit statevector are labelled by $\left[ c_{00}, c_{01}, c_{10}, c_{11} \right]$ as usual, then this corresponds to the operation $\ket{00} \rightarrow -i\ket{10}$.