### PR TITLE
fitting: Only use absolute_sigma=True when yerr is given

### DIFF
--- a/oitg/fitting/FitBase.py
+++ b/oitg/fitting/FitBase.py
@@ -338,7 +338,7 @@ class FitBase:
                          y,
                          init,
                          sigma=y_err,
-                         absolute_sigma=True,
+                         absolute_sigma=y_err is not None,
                          bounds=(lower, upper),
                          x_scale=scale,
                          method='trf')


### PR DESCRIPTION
When sigma=None is passed to scipy's curve_fit(…, absolute_sigma=True),
the internal equal weights (1.0 everywhere, presumably) are still
interpreted as error estimates on the input data, leading to nonsensical
parameter error estimates.

Without error erstimates on the y values, the absolute_sigma=False
behaviour, which is to scale the results to get a chi-squared of 1.0,
is the best we can do.
